### PR TITLE
Add health checks to helm chart

### DIFF
--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -59,10 +59,25 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /camunda/
+              path: {{ .Values.readinessProbe.path}}
               port: http
-            initialDelaySeconds: 60
-            periodSeconds: 60
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds}}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path}}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds}}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path}}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds}}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds}}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.database.internal.enabled -}}

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -68,6 +68,24 @@ ingress:
 
 podAnnotations: {}
 
+readinessProbe:
+  path: /camunda/
+  initialDelaySeconds: 120
+  periodSeconds: 60
+  timeoutSeconds: 1
+
+startupProbe:
+  path: /camunda/
+  initialDelaySeconds: 120
+  periodSeconds: 60
+  timeoutSeconds: 1
+
+livenessProbe:
+  path: /camunda/
+  initialDelaySeconds: 120
+  periodSeconds: 60
+  timeoutSeconds: 1
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
References: 
* https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
* https://aws.github.io/aws-eks-best-practices/reliability/docs/application/
* https://easoncao.com/zero-downtime-deployment-when-using-alb-ingress-controller-on-amazon-eks-and-prevent-502-error/
Tested via dry-run:
```
helm upgrade -i engine \
    ~/workspace/camunda-helm/charts/camunda-bpm-platform \
    -f ./k8s/dev/values.yaml \
    --set image.repository=038098751075.dkr.ecr.us-east-1.amazonaws.com/microservice-bedrock-camunda \
    --set image.tag=dev-9d7f8c674eefd9d57faa5fc8f05b4e65f9115b8d \
    -n camunda \
    --dry-run
```

Output:

```
# Source: camunda-bpm-platform/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: engine-camunda-bpm-platform
  labels:
    helm.sh/chart: camunda-bpm-platform-0.1.0
    app.kubernetes.io/name: camunda-bpm-platform
    app.kubernetes.io/instance: engine
    app.kubernetes.io/version: "latest"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 3
  selector:
    matchLabels:
      app.kubernetes.io/name: camunda-bpm-platform
      app.kubernetes.io/instance: engine
  template:
    metadata:
      annotations:
        vault.hashicorp.com/agent-inject: "true"
        vault.hashicorp.com/agent-inject-secret-dbcreds: camunda-dev/secret/data/camunda-config/database
        vault.hashicorp.com/agent-inject-status: update
        vault.hashicorp.com/agent-inject-template-dbcreds: |
          {{- with secret "camunda-dev/secret/data/camunda-config/database" -}}
            export DB_USERNAME={{ .Data.data.user }}
            export DB_PASSWORD={{ .Data.data.password }}
          {{- end -}}
        vault.hashicorp.com/role: camunda-dev
      labels:
        app.kubernetes.io/name: camunda-bpm-platform
        app.kubernetes.io/instance: engine
    spec:
      serviceAccountName: camunda
      securityContext:
        {}
      containers:
        - name: camunda-bpm-platform
          securityContext:
            {}
          image: "038098751075.dkr.ecr.us-east-1.amazonaws.com/microservice-bedrock-camunda:dev-9d7f8c674eefd9d57faa5fc8f05b4e65f9115b8d"
          imagePullPolicy: IfNotPresent
          env:
            - name: DEBUG
              value: "false"
            - name: JMX_PROMETHEUS
              value: "false"
            - name: DB_DRIVER
              value: "org.postgresql.Driver"
            - name: DB_URL
              value: "jdbc:postgresql://main.camunda-config.dev.blink.codes/postgres"
            - name: KINESIS_STREAM_ENABLED
              value: "true"
            - name: NEWRELIC_ENVIRONMENT
              value: "development"
            - name: TASK_KINESIS_STREAM
              value: "infra-dev-camunda-task-tskstream-kinesis"
            - name: WORKFLOW_KINESIS_STREAM
              value: "infra-dev-camunda-workflow-wfstream-kinesis"
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          readinessProbe:
            httpGet:
              path: /engine-rest/engine
              port: http
            initialDelaySeconds: 120
            periodSeconds: 60
            timeoutSeconds: 1
          livenessProbe:
            httpGet:
              path: /engine-rest/engine
              port: http
            initialDelaySeconds: 120
            periodSeconds: 60
            timeoutSeconds: 1
          startupProbe:
            httpGet:
              path: /engine-rest/engine
              port: http
            initialDelaySeconds: 120
            periodSeconds: 60
            timeoutSeconds: 1
          resources:
            limits:
              cpu: 500m
              memory: 3072Mi
            requests:
              cpu: 500m
              memory: 3072Mi
```